### PR TITLE
Automatically create per-thread instances of MmStats models

### DIFF
--- a/mmstats/models.py
+++ b/mmstats/models.py
@@ -8,9 +8,6 @@ from . import fields, libgettid, _mmap
 from .defaults import DEFAULT_PATH, DEFAULT_FILENAME
 
 
-tls = threading.local()
-
-
 class FieldState(object):
     """Holds field state for each Field instance"""
 
@@ -18,7 +15,7 @@ class FieldState(object):
         self.field = field
 
 
-class BaseMmStats(object):
+class BaseMmStats(threading.local):
     """Stats models should inherit from this"""
 
     def __init__(self, path=DEFAULT_PATH, filename=DEFAULT_FILENAME,
@@ -103,24 +100,6 @@ class BaseMmStats(object):
         # Remove fields to prevent segfaults
         self._fields = {}
         self._removed = True
-
-    @classmethod
-    def create_getter(cls, *args, **kwargs):
-        """Creates a *threadsafe* getter for your MmStats model
-
-        Passes `*args` and `**kwargs` directly to
-        :class:~mmstats.models.BaseMmStats
-        """
-        key = cls.__name__
-
-        def getter():
-            instance = getattr(tls, key, None)
-            if instance is None:
-                instance = cls(*args, **kwargs)
-                setattr(tls, key, instance)
-            return instance
-
-        return getter
 
 
 class MmStats(BaseMmStats):

--- a/tests/test_mmstats.py
+++ b/tests/test_mmstats.py
@@ -58,9 +58,14 @@ class TestMmStats(base.MmstatsTestCase):
                 ready.wait()
 
         threads = [T() for _ in range(num_threads)]
-        [t.start() for t in threads]
+
+        for t in threads:
+            t.start()
+
         ready.set()  # go!
-        [t.join() for t in threads]
+
+        for t in threads:
+            t.join()
 
         self.assertFalse(collision['status'])
         self.assertEqual(len(stats), num_threads)


### PR DESCRIPTION
MmStats models are _not_ threadsafe, but creating an-instance-per-thread is tedious and error prone...

...unless your model just subclasses threading.local. In which case the threading.local base class will happily call **init** every time a global instance is used from a new thread.

See: https://bitbucket.org/mirror/cpython/src/ed76eac4491e/Lib/_threading_local.py#cl-56
