### PR TITLE
Better thread cleanup

### DIFF
--- a/mmstats/models.py
+++ b/mmstats/models.py
@@ -129,9 +129,8 @@ class BaseMmStats(threading.local):
         self._remove()
         # Then ensure we clean up any forgotten thread-related files, if
         # applicable.
-        if '{TID}' not in self._filename:
-            return
-        self._remove_stale_thread_files()
+        if '{TID}' in self._filename:
+            self._remove_stale_thread_files()
 
     def _remove_stale_thread_files(self):
         # The originally given (to __init__) filename string, containing

--- a/mmstats/models.py
+++ b/mmstats/models.py
@@ -128,8 +128,9 @@ class BaseMmStats(threading.local):
         # Perform regular removal of this process/thread's own file.
         self._remove()
         # Then ensure we clean up any forgotten thread-related files, if
-        # applicable.
-        if '{TID}' in self._filename:
+        # applicable. Ensure {PID} exists, for safety's sake - better to not
+        # cleanup than to cleanup multiple PIDs' files.
+        if '{PID}' in self._filename and '{TID}' in self._filename:
             self._remove_stale_thread_files()
 
     def _remove_stale_thread_files(self):

--- a/mmstats/models.py
+++ b/mmstats/models.py
@@ -125,13 +125,14 @@ class BaseMmStats(threading.local):
         _mmap.msync(self._mm_ptr, self._size, async)
 
     def remove(self):
-        # Perform regular removal of this process/thread's own file.
-        self._remove()
-        # Then ensure we clean up any forgotten thread-related files, if
-        # applicable. Ensure {PID} exists, for safety's sake - better to not
-        # cleanup than to cleanup multiple PIDs' files.
-        if '{PID}' in self._filename and '{TID}' in self._filename:
-            self._remove_stale_thread_files()
+        with threading.Lock():
+            # Perform regular removal of this process/thread's own file.
+            self._remove()
+            # Then ensure we clean up any forgotten thread-related files, if
+            # applicable. Ensure {PID} exists, for safety's sake - better to not
+            # cleanup than to cleanup multiple PIDs' files.
+            if '{PID}' in self._filename and '{TID}' in self._filename:
+                self._remove_stale_thread_files()
 
     def _remove_stale_thread_files(self):
         # The originally given (to __init__) filename string, containing

--- a/mmstats/models.py
+++ b/mmstats/models.py
@@ -1,4 +1,5 @@
 import ctypes
+import glob
 import os
 import sys
 import time
@@ -139,9 +140,7 @@ class BaseMmStats(threading.local):
         # given PID.
         globbed = self._filename.replace('{TID}', '*')
         # Re-expand any non-{TID} expansion hints
-        expanded = mmstats.models._expand_filename(
-            path=self._path, filename=globbed
-        )
+        expanded = _expand_filename(path=self._path, filename=globbed)
         # And nuke as appropriate.
         for leftover in glob.glob(expanded):
             os.remove(leftover)

--- a/mmstats/models.py
+++ b/mmstats/models.py
@@ -9,6 +9,9 @@ from . import fields, libgettid, _mmap
 from .defaults import DEFAULT_PATH, DEFAULT_FILENAME
 
 
+removal_lock = threading.Lock()
+
+
 def _expand_filename(path=DEFAULT_PATH, filename=DEFAULT_FILENAME):
     """Compute mmap's full path given a `path` and `filename`.
 
@@ -125,7 +128,7 @@ class BaseMmStats(threading.local):
         _mmap.msync(self._mm_ptr, self._size, async)
 
     def remove(self):
-        with threading.Lock():
+        with removal_lock:
             # Perform regular removal of this process/thread's own file.
             self._remove()
             # Then ensure we clean up any forgotten thread-related files, if

--- a/tests/base.py
+++ b/tests/base.py
@@ -7,12 +7,16 @@ import mmstats
 
 
 class MmstatsTestCase(unittest.TestCase):
+    @property
+    def files(self):
+        return glob.glob(os.path.join(self.path, 'test*.mmstats'))
+
     def setUp(self):
         super(MmstatsTestCase, self).setUp()
         self.path = mmstats.DEFAULT_PATH
 
         # Clean out stale mmstats files
-        for fn in glob.glob(os.path.join(self.path, 'test*.mmstats')):
+        for fn in self.files:
             try:
                 os.remove(fn)
                 pass
@@ -21,7 +25,7 @@ class MmstatsTestCase(unittest.TestCase):
 
     def tearDown(self):
         # clean the dir after tests
-        for fn in glob.glob(os.path.join(self.path, 'test*.mmstats')):
+        for fn in self.files:
             try:
                 os.remove(fn)
                 pass

--- a/tests/test_mmstats.py
+++ b/tests/test_mmstats.py
@@ -37,7 +37,7 @@ class TestMmStats(base.MmstatsTestCase):
             # The behavior we're testing is in MmStats itself
             pass
         # Ensure we use {TID}
-        s = ThreadedStats(filename='test-thread-cleanup-{TID}.mmstats')
+        s = ThreadedStats(filename='test-thread-cleanup-{PID}-{TID}.mmstats')
         # Threading
         ready = threading.Event()
         class WorkThread(threading.Thread):


### PR DESCRIPTION
Use globbing and `{TID}` to ensure that `.remove()` cleans up all thread-related mmstats files, not just the master or current thread's file. This addresses #30.
